### PR TITLE
[2024.10.23] 오민지 01matrix failed

### DIFF
--- a/solutions/01matrix.js
+++ b/solutions/01matrix.js
@@ -1,0 +1,41 @@
+/**
+ * @param {number[][]} mat
+ * @return {number[][]}
+ */
+
+var changed=[]
+var updateMatrix = function(mat) {
+    for(let i = 0; i < mat.length; i++) {
+        for(let j = 0; j < mat[0].length; j++) {
+            if(mat[i][j] === 1) {
+                mat[i][j] = bfs(mat, i, j);
+                changed.push([i, j])
+            }
+        }
+    }
+    return mat;
+};
+
+function bfs(mat, i, j) {
+    var queue = [];
+    queue.push([i, j]);
+    var ans = 0;
+    while(queue.length > 0) {
+        var [x, y] = queue.shift();
+        var dx = [1, -1, 0, 0];
+        var dy = [0, 0, 1, -1];
+
+        for(let k = 0; k < 4; k++) {
+            var nx = x + dx[k];
+            var ny = y + dy[k];
+
+            if(nx >= mat.length || nx < 0 || ny >= mat[0].length || ny < 0 || mat[nx][ny] ===0){
+                return ans + 1;
+            } 
+            else {
+                continue;
+            }
+        }
+        ans++;
+    }
+} 

--- a/solutions/01matrix.js
+++ b/solutions/01matrix.js
@@ -2,40 +2,32 @@
  * @param {number[][]} mat
  * @return {number[][]}
  */
-
-var changed=[]
 var updateMatrix = function(mat) {
-    for(let i = 0; i < mat.length; i++) {
-        for(let j = 0; j < mat[0].length; j++) {
-            if(mat[i][j] === 1) {
-                mat[i][j] = bfs(mat, i, j);
-                changed.push([i, j])
+    const m = mat.length, n = mat[0].length;
+    const queue = [];
+    const MAX_VALUE = m * n;
+
+    for (let i = 0; i < m; i++) {
+        for (let j = 0; j < n; j++) {
+            if (mat[i][j] === 0) {
+                queue.push([i, j]);
+            } else {
+                mat[i][j] = MAX_VALUE;
             }
         }
     }
+    
+    const directions = [[1, 0], [-1, 0], [0, 1], [0, -1]];
+    while (queue.length) {
+        const [x, y] = queue.shift();
+        for (const [dx, dy] of directions) {
+            const nx = x + dx, ny = y + dy;
+            if (nx >= 0 && nx < m && ny >= 0 && ny < n && mat[nx][ny] > mat[x][y] + 1) {
+                mat[nx][ny] = mat[x][y] + 1;
+                queue.push([nx, ny]);
+            }
+        }
+    }
+    
     return mat;
 };
-
-function bfs(mat, i, j) {
-    var queue = [];
-    queue.push([i, j]);
-    var ans = 0;
-    while(queue.length > 0) {
-        var [x, y] = queue.shift();
-        var dx = [1, -1, 0, 0];
-        var dy = [0, 0, 1, -1];
-
-        for(let k = 0; k < 4; k++) {
-            var nx = x + dx[k];
-            var ny = y + dy[k];
-
-            if(nx >= mat.length || nx < 0 || ny >= mat[0].length || ny < 0 || mat[nx][ny] ===0){
-                return ans + 1;
-            } 
-            else {
-                continue;
-            }
-        }
-        ans++;
-    }
-} 


### PR DESCRIPTION
# geezer-algo-study

## 풀이시간

> 40분?

<br>

## 문제 해결방법

> 실패한 방법: 1인 셀을 큐에 넣고 거리 구하기
성공한 방법: 0인 셀을 큐에 넣고 거리 구하기

**0인 셀을 먼저 큐에 넣는 것이 더 효율적인 이유**
시작점 최적화: 0인 셀들을 시작점으로 사용하면 모든 1인 셀에 대해 개별적으로 BFS를 수행할 필요가 없어짐
동시 탐색: 여러 0인 셀에서 동시에 BFS를 시작함으로써, 한 번의 BFS로 모든 1인 셀까지의 최단 거리를 계산할 수 있음
중복 계산 방지: 각 1인 셀에 대해 개별적으로 BFS를 수행하면 많은 중복 계산이 발생하지만, 0인 셀에서 시작하면 이를 크게 줄일 수 있음
메모리 효율성: 한 번의 BFS로 모든 계산을 수행하므로, 여러 번의 개별 BFS를 실행할 때 필요한 추가적인 메모리 사용을 피할 수 있음
시간 복잡도 개선: 이 방법을 사용하면 알고리즘의 전체 실행 시간을 크게 줄일 수 있습니다. 특히 0인 셀의 수가 상대적으로 적을 때 더욱 효과적

<br>

## 시간 복잡도

> O((m×n))

<br>

### 🫡 오늘도 고생하셨습니다!
